### PR TITLE
Fix the $in serialisation problem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -271,6 +271,13 @@
                 <role>developer</role>
             </roles>
         </contributor>
+         <contributor>
+            <name>Yann Deshayes</name>
+            <url>https://github.com/ydeshayes</url>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </contributor>
     </contributors>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -271,7 +271,7 @@
                 <role>developer</role>
             </roles>
         </contributor>
-         <contributor>
+        <contributor>
             <name>Yann Deshayes</name>
             <url>https://github.com/ydeshayes</url>
             <roles>

--- a/src/main/java/org/mongojack/internal/util/SerializationUtils.java
+++ b/src/main/java/org/mongojack/internal/util/SerializationUtils.java
@@ -183,18 +183,17 @@ public class SerializationUtils {
             List<Object> serializedConditions = new ArrayList<Object>();
             for (QueryCondition item : coll.getValues()) {
                if(key.startsWith("$in")){
-					SimpleQueryCondition simple = (SimpleQueryCondition) item;
-					if(String.class.isInstance(simple.getValue())){
-						serializedConditions.add(simple.getValue());
-					}else{
-						serializedConditions.add(serializeQueryCondition(
-								serializerProvider, serializer, "$", item));
-					}
-				}else{
-
-					serializedConditions.add(serializeQueryCondition(
-							serializerProvider, serializer, "$", item));
-				}
+	           SimpleQueryCondition simple = (SimpleQueryCondition) item;
+		   if(String.class.isInstance(simple.getValue())){
+		       serializedConditions.add(simple.getValue());
+		   }else{
+		       serializedConditions.add(serializeQueryCondition(
+						serializerProvider, serializer, "$", item));
+		   }
+	       }else{
+		   serializedConditions.add(serializeQueryCondition(
+					serializerProvider, serializer, "$", item));
+	       }
             }
             return serializedConditions;
         } else {

--- a/src/main/java/org/mongojack/internal/util/SerializationUtils.java
+++ b/src/main/java/org/mongojack/internal/util/SerializationUtils.java
@@ -182,8 +182,19 @@ public class SerializationUtils {
             }
             List<Object> serializedConditions = new ArrayList<Object>();
             for (QueryCondition item : coll.getValues()) {
-                serializedConditions.add(serializeQueryCondition(
-                        serializerProvider, serializer, "$", item));
+               if(key.startsWith("$in")){
+					SimpleQueryCondition simple = (SimpleQueryCondition) item;
+					if(String.class.isInstance(simple.getValue())){
+						serializedConditions.add(simple.getValue());
+					}else{
+						serializedConditions.add(serializeQueryCondition(
+								serializerProvider, serializer, "$", item));
+					}
+				}else{
+
+					serializedConditions.add(serializeQueryCondition(
+							serializerProvider, serializer, "$", item));
+				}
             }
             return serializedConditions;
         } else {

--- a/src/main/java/org/mongojack/internal/util/SerializationUtils.java
+++ b/src/main/java/org/mongojack/internal/util/SerializationUtils.java
@@ -182,7 +182,7 @@ public class SerializationUtils {
             }
             List<Object> serializedConditions = new ArrayList<Object>();
             for (QueryCondition item : coll.getValues()) {
-               if(key.startsWith("$in")){
+               if(key.startsWith("$in") || key.startsWith("$nin")){
 	           SimpleQueryCondition simple = (SimpleQueryCondition) item;
 		   if(String.class.isInstance(simple.getValue())){
 		       serializedConditions.add(simple.getValue());


### PR DESCRIPTION
see: https://github.com/devbliss/mongojack/issues/27.

When we do a DBQuery.in("theArray", listString); the plugin was crashing with Execution exception[[ClassCastException: java.lang.String cannot be cast to java.util.Collection]]

I did the modifications for that problem, I check if the value on the SimpleQueryCondition is a String, and if it's a String I just add the value to the serializedConditions.