### PR TITLE
test case for queries with "in"

### DIFF
--- a/src/test/java/org/mongojack/TestQuerySerialization.java
+++ b/src/test/java/org/mongojack/TestQuerySerialization.java
@@ -22,11 +22,15 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mongojack.DBQuery.Query;
+import org.mongojack.mock.MockObjectWithListOfStringsWithGettersSetters;
+import org.mongojack.mock.MockObjectWithListOfStringsWithoutGettersSetters;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -37,6 +41,7 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.mongodb.DBCollection;
 
 public class TestQuerySerialization extends MongoDBTestBase {
 
@@ -128,6 +133,58 @@ public class TestQuerySerialization extends MongoDBTestBase {
                 hasSize(1));
     }
 
+    @Test
+    public void testInQueryWithCollectionAndArrayOfStringsWithGettersSetters() {
+        DBCollection c1 = getCollection("blah_" + Math.round(Math.random() * 10000d));
+        JacksonDBCollection<MockObjectWithListOfStringsWithGettersSetters, String> c2 = JacksonDBCollection.wrap(c1, MockObjectWithListOfStringsWithGettersSetters.class, String.class);
+        Query q = DBQuery.empty().in("simpleList", (Object) new String[] { "b" });
+        c2.find(q);
+    }
+
+    @Test
+    public void testInQueryWithCollectionAndSingleStringWithGettersSetters() {
+        DBCollection c1 = getCollection("blah_" + Math.round(Math.random() * 10000d));
+        JacksonDBCollection<MockObjectWithListOfStringsWithGettersSetters, String> c2 = JacksonDBCollection.wrap(c1, MockObjectWithListOfStringsWithGettersSetters.class, String.class);
+        Query q = DBQuery.empty().in("simpleList", "b");
+        c2.find(q);
+    }
+
+    @Test
+    public void testInQueryWithCollectionAndCollectionOfStringsWithGettersSetters() {
+        DBCollection c1 = getCollection("blah_" + Math.round(Math.random() * 10000d));
+        JacksonDBCollection<MockObjectWithListOfStringsWithGettersSetters, String> c2 = JacksonDBCollection.wrap(c1, MockObjectWithListOfStringsWithGettersSetters.class, String.class);
+        List<String> x = new ArrayList<String>();
+        x.add("b");
+        Query q = DBQuery.empty().in("simpleList", x);
+        c2.find(q);
+    }
+
+    @Test
+    public void testInQueryWithCollectionAndArrayOfStringsWithoutGettersSetters() {
+        DBCollection c1 = getCollection("blah_" + Math.round(Math.random() * 10000d));
+        JacksonDBCollection<MockObjectWithListOfStringsWithoutGettersSetters, String> c2 = JacksonDBCollection.wrap(c1, MockObjectWithListOfStringsWithoutGettersSetters.class, String.class);
+        Query q = DBQuery.empty().in("simpleList", (Object) new String[] { "b" });
+        c2.find(q);
+    }
+
+    @Test
+    public void testInQueryWithCollectionAndSingleStringWithoutGettersSetters() {
+        DBCollection c1 = getCollection("blah_" + Math.round(Math.random() * 10000d));
+        JacksonDBCollection<MockObjectWithListOfStringsWithoutGettersSetters, String> c2 = JacksonDBCollection.wrap(c1, MockObjectWithListOfStringsWithoutGettersSetters.class, String.class);
+        Query q = DBQuery.empty().in("simpleList", "b");
+        c2.find(q);
+    }
+
+    @Test
+    public void testInQueryWithCollectionAndCollectionOfStringsWithoutGettersSetters() {
+        DBCollection c1 = getCollection("blah_" + Math.round(Math.random() * 10000d));
+        JacksonDBCollection<MockObjectWithListOfStringsWithoutGettersSetters, String> c2 = JacksonDBCollection.wrap(c1, MockObjectWithListOfStringsWithoutGettersSetters.class, String.class);
+        List<String> x = new ArrayList<String>();
+        x.add("b");
+        Query q = DBQuery.empty().in("simpleList", x);
+        c2.find(q);
+    }
+    
     public static class MockObject {
         @ObjectId
         @Id

--- a/src/test/java/org/mongojack/mock/MockObjectWithListOfStringsWithGettersSetters.java
+++ b/src/test/java/org/mongojack/mock/MockObjectWithListOfStringsWithGettersSetters.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2011 VZ Netzwerke Ltd
+ * Copyright 2014 devbliss GmbH
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongojack.mock;
+
+import java.util.List;
+
+/**
+ * Test object with one of each field
+ */
+public class MockObjectWithListOfStringsWithGettersSetters {
+
+    private String _id;
+    private List<String> simpleList;
+
+    public MockObjectWithListOfStringsWithGettersSetters() {
+    }
+
+    public String get_id() {
+        return _id;
+    }
+
+    public void set_id(String _id) {
+        this._id = _id;
+    }
+
+    public List<String> getSimpleList() {
+        return simpleList;
+    }
+
+    public void setSimpleList(List<String> simpleList) {
+        this.simpleList = simpleList;
+    }
+}

--- a/src/test/java/org/mongojack/mock/MockObjectWithListOfStringsWithoutGettersSetters.java
+++ b/src/test/java/org/mongojack/mock/MockObjectWithListOfStringsWithoutGettersSetters.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2011 VZ Netzwerke Ltd
+ * Copyright 2014 devbliss GmbH
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongojack.mock;
+
+import java.util.List;
+
+/**
+ * Test object with one of each field
+ */
+public class MockObjectWithListOfStringsWithoutGettersSetters {
+
+    private String _id;
+    private List<String> simpleList;
+
+    public MockObjectWithListOfStringsWithoutGettersSetters() {
+    }
+}


### PR DESCRIPTION
hi,

i already sent a pull request a while ago - this time, the test case comes first. the issue is that the wrong serializer is used for serializing a query under certain circumstances, in this case:

- the document has a collection with the name "simpleList" (which is, on the java side, a java.util.List)
- i try to do an "$in" query, passing in the name of the field ("simpleList") and one or more values.
- the error happens somewhere in serialization utils - the serializer for the TYPE of the field is used, so the utils try to serialize a string ("simpleList") with StringCollectionSerializer, resulting in an exception:


    java.lang.ClassCastException: java.lang.String cannot be cast to java.util.Collection
    	at com.fasterxml.jackson.databind.ser.impl.StringCollectionSerializer.serialize(StringCollectionSerializer.java:24)
    	at org.mongojack.internal.util.SerializationUtils.serializeQueryField(SerializationUtils.java:257)
    	at org.mongojack.internal.util.SerializationUtils.serializeQueryCondition(SerializationUtils.java:174)
    	at org.mongojack.internal.util.SerializationUtils.serializeQueryCondition(SerializationUtils.java:185)
    	at org.mongojack.internal.util.SerializationUtils.serializeQuery(SerializationUtils.java:146)
    	at org.mongojack.internal.util.SerializationUtils.serializeQueryCondition(SerializationUtils.java:195)
    	at org.mongojack.internal.util.SerializationUtils.serializeQuery(SerializationUtils.java:146)
    	at org.mongojack.internal.util.SerializationUtils.serializeQuery(SerializationUtils.java:134)    
    	at org.mongojack.JacksonDBCollection.serializeQuery(JacksonDBCollection.java:2313)
    	at org.mongojack.JacksonDBCollection.find(JacksonDBCollection.java:1180)
             [...]