### PR TITLE
Preparing for the 3.0 Java driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
-            <version>2.12.5</version>
+            <version>2.13.0-rc2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/org/mongojack/DBCursor.java
+++ b/src/main/java/org/mongojack/DBCursor.java
@@ -311,7 +311,9 @@ public class DBCursor<T> extends DBQuery.AbstractBuilder<DBCursor<T>> implements
      * the database
      * 
      * @return The number of get mores
+     * @deprecated there is no replacement for this method
      */
+    @Deprecated
     public int numGetMores() {
         return cursor.numGetMores();
     }
@@ -320,7 +322,9 @@ public class DBCursor<T> extends DBQuery.AbstractBuilder<DBCursor<T>> implements
      * gets a simpleList containing the number of items received in each batch
      * 
      * @return The sizes of each batch
+     * @deprecated there is no replacement for this method
      */
+    @Deprecated
     public List<Integer> getSizes() {
         return cursor.getSizes();
     }

--- a/src/main/java/org/mongojack/JacksonDBCollection.java
+++ b/src/main/java/org/mongojack/JacksonDBCollection.java
@@ -1070,7 +1070,7 @@ public class JacksonDBCollection<T, K> {
     }
 
     /**
-     * calls {@link DBCollection#ensureIndex(com.mongodb.DBObject, com.mongodb.DBObject)} with default options
+     * calls {@link DBCollection#createIndex(com.mongodb.DBObject, com.mongodb.DBObject)} with default options
      * 
      * @param keys
      *            an object with a key set of the fields desired for the index
@@ -1079,11 +1079,11 @@ public class JacksonDBCollection<T, K> {
      */
     @Deprecated
     public void ensureIndex(DBObject keys) throws MongoException {
-        dbCollection.ensureIndex(keys);
+        dbCollection.createIndex(keys);
     }
 
     /**
-     * calls {@link DBCollection#ensureIndex(com.mongodb.DBObject, java.lang.String, boolean)} with unique=false
+     * calls {@link DBCollection#createIndex(com.mongodb.DBObject, java.lang.String, boolean)} with unique=false
      * 
      * @param keys
      *            fields to use for index
@@ -1114,7 +1114,7 @@ public class JacksonDBCollection<T, K> {
     @Deprecated
     public void ensureIndex(DBObject keys, String name, boolean unique)
             throws MongoException {
-        dbCollection.ensureIndex(keys, name, unique);
+        dbCollection.createIndex(keys, name, unique);
     }
 
     /**
@@ -1130,7 +1130,7 @@ public class JacksonDBCollection<T, K> {
     @Deprecated
     public void ensureIndex(DBObject keys, DBObject optionsIN)
             throws MongoException {
-        dbCollection.ensureIndex(keys, optionsIN);
+        dbCollection.createIndex(keys, optionsIN);
     }
 
     /**

--- a/src/main/java/org/mongojack/MapReduce.java
+++ b/src/main/java/org/mongojack/MapReduce.java
@@ -217,7 +217,9 @@ public class MapReduce {
          * @param extra
          *            The extra arguments
          * @return this command
+         * @deprecated  use the specific setter methods
          */
+        @Deprecated
         public MapReduceCommand<T, K> setExtra(DBObject extra) {
             this.extra = extra;
             return this;

--- a/src/main/java/org/mongojack/MapReduceOutput.java
+++ b/src/main/java/org/mongojack/MapReduceOutput.java
@@ -78,6 +78,52 @@ public class MapReduceOutput<T, K> {
         return outputCollection;
     }
 
+    /**
+     * Get the amount of time, in milliseconds, that it took to run this map reduce.
+     *
+     * @return an int representing the number of milliseconds it took to run the map reduce operation
+     */
+    public int getDuration() {
+        return output.getDuration();
+    }
+
+    /**
+     * Get the number of documents that were input into the map reduce operation
+     *
+     * @return the number of documents that read while processing this map reduce
+     */
+    public int getInputCount() {
+        return output.getInputCount();
+    }
+
+    /**
+     * Get the number of documents generated as a result of this map reduce
+     *
+     * @return the number of documents output by the map reduce
+     */
+    public int getOutputCount() {
+        return output.getOutputCount();
+    }
+
+    /**
+     * Get the number of messages emitted from the provided map function.
+     *
+     * @return the number of items emitted from the map function
+     */
+    public int getEmitCount() {
+        return output.getEmitCount();
+    }
+
+    /**
+     * Gets the raw command result of the operation.
+     *
+     * @return a CommandResult representing the output of the map-reduce in its raw form from the server.
+     * @deprecated It is not recommended to access the command result returned by the server as the format can change between releases. This
+     * has been replaced with a series of specific getters for the values on the CommandResult (
+     * getDuration, getEmitCount, getOutputCount, getInputCount).  The method {@code results()} will continue to return an {@code
+     * Iterable<T>}, that should be used to obtain the results of the map-reduce.
+     */
+    @Deprecated
     public CommandResult getCommandResult() {
         return output.getCommandResult();
     }
@@ -86,6 +132,13 @@ public class MapReduceOutput<T, K> {
         return output.getCommand();
     }
 
+    /**
+     * Get the server that the  command was run on.
+     *
+     * @return a ServerAddress of the server that the command ran against.
+     * @deprecated this method will be removed in a future release.  There is no replacement for it.
+     */
+    @Deprecated
     public ServerAddress getServerUsed() {
         return output.getServerUsed();
     }

--- a/src/main/java/org/mongojack/WriteResult.java
+++ b/src/main/java/org/mongojack/WriteResult.java
@@ -173,7 +173,10 @@ public class WriteResult<T, K> {
      * Gets the last result from getLastError()
      * 
      * @return The last error
+     * @deprecated Use the appropriate {@code WriteConcern} and rely on the write operation to throw an exception on failure.  For
+     * successful writes, use the helper methods to retrieve specific values from the write response.
      */
+    @Deprecated
     public CommandResult getCachedLastError() {
         return writeResult.getCachedLastError();
 
@@ -184,7 +187,9 @@ public class WriteResult<T, K> {
      * getLastError()
      * 
      * @return The last write concern.
+     * @deprecated there is no replacement for this method
      */
+    @Deprecated
     public WriteConcern getLastConcern() {
         return writeResult.getLastConcern();
 
@@ -195,7 +200,10 @@ public class WriteResult<T, K> {
      * concern=null
      * 
      * @return The last error
+     * @deprecated Use the appropriate {@code WriteConcern} and allow the write operation to throw an exception on failure.  For
+     * successful writes, use the helper methods to retrieve specific values from the write response.
      */
+    @Deprecated
     public synchronized CommandResult getLastError() {
         return writeResult.getLastError();
     }
@@ -209,7 +217,10 @@ public class WriteResult<T, K> {
      * @param concern
      *            the concern
      * @return The last error for the concern
+     * @deprecated Use the appropriate {@code WriteConcern} and rely on the write operation to throw an exception on failure.  For
+     * successful writes, use the helper methods to retrieve specific values from the write response.
      */
+    @Deprecated
     public synchronized CommandResult getLastError(WriteConcern concern) {
         return writeResult.getLastError(concern);
     }
@@ -218,7 +229,10 @@ public class WriteResult<T, K> {
      * Gets the error String ("err" field)
      * 
      * @return The error string
+     * @deprecated There should be no reason to use this method.  The error message will be in the exception thrown for an
+     * unsuccessful write operation.
      */
+    @Deprecated
     public String getError() {
         return writeResult.getError();
     }
@@ -234,12 +248,35 @@ public class WriteResult<T, K> {
     }
 
     /**
+     * Gets the _id value of an upserted document that resulted from this write.  Note that for MongoDB servers prior to version 2.6,
+     * this method will return null unless the _id of the upserted document was of type ObjectId.
+     *
+     * @return the value of the _id of an upserted document
+     */
+    public Object getUpsertedId() {
+        return writeResult.getUpsertedId();
+    }
+
+
+    /**
+     * Returns true if this write resulted in an update of an existing document.
+     *
+     * @return whether the write resulted in an update of an existing document.
+     */
+    public boolean isUpdateOfExisting() {
+        return writeResult.isUpdateOfExisting();
+    }
+
+    /**
      * Gets a field
      * 
      * @param name
      *            field name
      * @return The value
+     * @deprecated There should be no reason to use this method.  To get specific fields from a successful write,
+     * use the helper methods provided.  Any error-related fields will be in the exception thrown for an unsuccessful write operation.
      */
+    @Deprecated
     public Object getField(String name) {
         return writeResult.getField(name);
     }
@@ -249,7 +286,9 @@ public class WriteResult<T, K> {
      * not called automatically
      * 
      * @return if it's lazy
+     * @deprecated there is no replacement for this method
      */
+    @Deprecated
     public boolean isLazy() {
         return writeResult.isLazy();
     }

--- a/src/main/java/org/mongojack/internal/DBRefDeserializer.java
+++ b/src/main/java/org/mongojack/internal/DBRefDeserializer.java
@@ -71,7 +71,7 @@ public class DBRefDeserializer<T, K> extends JsonDeserializer<DBRef> {
                     } else {
                         id = (K) ((com.mongodb.DBRef) object).getId();
                     }
-                    collectionName = ((com.mongodb.DBRef) object).getRef();
+                    collectionName = ((com.mongodb.DBRef) object).getCollectionName();
                 } else {
                     throw ctxt.instantiationException(DBRef.class,
                             "Don't know what to do with embedded object: "

--- a/src/main/java/org/mongojack/internal/DBRefSerializer.java
+++ b/src/main/java/org/mongojack/internal/DBRefSerializer.java
@@ -56,8 +56,7 @@ public class DBRefSerializer extends MongoSerializer<DBRef> {
         if (value == null) {
             bgen.writeNull();
         } else {
-            bgen.writeObject(new com.mongodb.DBRef(null, value
-                    .getCollectionName(), value.getId()));
+            bgen.writeObject(new com.mongodb.DBRef(value.getCollectionName(), value.getId()));
         }
     }
 

--- a/src/main/java/org/mongojack/internal/ObjectIdSerializer.java
+++ b/src/main/java/org/mongojack/internal/ObjectIdSerializer.java
@@ -63,7 +63,7 @@ public class ObjectIdSerializer extends JsonSerializer {
             if (id == null) {
                 return null;
             }
-            return new com.mongodb.DBRef(null, dbRef.getCollectionName(), id);
+            return new com.mongodb.DBRef(dbRef.getCollectionName(), id);
         } else if (value instanceof ObjectId) {
             return value;
         } else {

--- a/src/main/java/org/mongojack/internal/stream/DBEncoderBsonGenerator.java
+++ b/src/main/java/org/mongojack/internal/stream/DBEncoderBsonGenerator.java
@@ -50,13 +50,9 @@ public class DBEncoderBsonGenerator extends BsonGenerator {
             DBRef dbRef = (DBRef) value;
             writeStartObject();
             writeFieldName("$ref");
-            writeString(dbRef.getRef());
+            writeString(dbRef.getCollectionName());
             writeFieldName("$id");
             writeObject(dbRef.getId());
-            if (dbRef.getDB() != null) {
-                writeFieldName("$db");
-                writeString(dbRef.getDB().getName());
-            }
             writeEndObject();
         } else {
             super._writeSimpleObject(value);

--- a/src/main/java/org/mongojack/internal/stream/ObjectIdConvertor.java
+++ b/src/main/java/org/mongojack/internal/stream/ObjectIdConvertor.java
@@ -27,12 +27,22 @@ import org.bson.types.ObjectId;
 public class ObjectIdConvertor {
 
     public static ObjectId convert(de.undercouch.bson4jackson.types.ObjectId objectId) {
-        return new ObjectId(objectId.getTime(), objectId.getMachine(), objectId.getInc());
+        return ObjectId.createFromLegacyFormat(objectId.getTime(), objectId.getMachine(), objectId.getInc());
     }
 
     public static de.undercouch.bson4jackson.types.ObjectId convert(ObjectId objectId) {
-        return new de.undercouch.bson4jackson.types.ObjectId(objectId.getTimeSecond(), objectId.getMachine(),
-                objectId.getInc());
+        byte[] bytes = objectId.toByteArray();
+
+        return new de.undercouch.bson4jackson.types.ObjectId(makeInt(bytes[0], bytes[1], bytes[2], bytes[3]),
+                                                             makeInt(bytes[4], bytes[5], bytes[6], bytes[7]),
+                                                             makeInt(bytes[8], bytes[9], bytes[10], bytes[11]));
+    }
+
+    private static int makeInt(final byte b3, final byte b2, final byte b1, final byte b0) {
+        return (((b3) << 24) |
+                ((b2 & 0xff) << 16) |
+                ((b1 & 0xff) << 8) |
+                ((b0 & 0xff)));
     }
 
 }

--- a/src/test/java/org/mongojack/internal/stream/TestObjectIdConvertor.java
+++ b/src/test/java/org/mongojack/internal/stream/TestObjectIdConvertor.java
@@ -1,0 +1,25 @@
+package org.mongojack.internal.stream;
+
+import de.undercouch.bson4jackson.types.ObjectId;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class TestObjectIdConvertor {
+    @Test
+    public void testConversion() {
+        ObjectId jacksonObjectId = new ObjectId(Integer.MAX_VALUE, 0xff, 0xf);
+        org.bson.types.ObjectId javaDriverObjectId = ObjectIdConvertor.convert(jacksonObjectId);
+
+        byte[] expectedBytes = {127, -1, -1, -1, 0, 0, 0, -1, 0, 0, 0, 15};
+
+        assertThat(javaDriverObjectId.toByteArray(), equalTo(expectedBytes));
+
+        ObjectId convertedJacksonObjectId = ObjectIdConvertor.convert(javaDriverObjectId);
+
+        assertThat(jacksonObjectId.getInc(), equalTo(convertedJacksonObjectId.getInc()));
+        assertThat(jacksonObjectId.getMachine(), equalTo(convertedJacksonObjectId.getMachine()));
+        assertThat(jacksonObjectId.getTime(), equalTo(convertedJacksonObjectId.getTime()));
+    }
+}


### PR DESCRIPTION
The 3.0 Java driver API has stabilized, and I've been looking at MongoJack to see what it would take to upgrade its dependency on mongo-java-driver to 3.0.  

Some of the changes are completely internal, while others require that methods in the MongoJack public API be deprecated and then eventually removed before updating the dependency.  The second, third, and fourth commits fall in the internal category, while the last four fall in the deprecation category.

Let me know what you think, and I'm happy to discuss further.