### PR TITLE
Aggregation.Expression builder: add missing list() path method

### DIFF
--- a/src/main/java/org/mongojack/Aggregation.java
+++ b/src/main/java/org/mongojack/Aggregation.java
@@ -519,6 +519,10 @@ public class Aggregation<T> {
             return new FieldPath<Integer>(path);
         }
 
+        public static Expression<List<?>> list(String... path) {
+            return new FieldPath<List<?>>(path);
+        }
+
         public static Expression<Number> number(String... path) {
             return new FieldPath<Number>(path);
         }


### PR DESCRIPTION
Required to build set/array operator expressions.  See `TestAggregationBuilder.testSize()` for example usage.