### PR TITLE
Use recursively determined fieldSerializer when looking up field update serializers.

### DIFF
--- a/src/main/java/org/mongojack/internal/util/SerializationUtils.java
+++ b/src/main/java/org/mongojack/internal/util/SerializationUtils.java
@@ -458,7 +458,7 @@ public class SerializationUtils {
                 } else if (fieldSerializer instanceof BeanSerializerBase) {
                     BeanPropertyWriter writer = JacksonAccessor
                             .findPropertyWriter(
-                                    (BeanSerializerBase) serializer, field);
+                                    (BeanSerializerBase) fieldSerializer, field);
                     if (writer != null) {
                         fieldSerializer = writer.getSerializer();
                         if (fieldSerializer == null) {


### PR DESCRIPTION
Use recursively determined fieldSerializer when looking up field update serializers. Closes #98.