### PR TITLE
Use mongo-java-driver 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.mongojack</groupId>
     <artifactId>mongojack</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>MongoJack</name>
@@ -25,7 +25,8 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
-            <version>2.13.0</version>
+            <version>3.0.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -56,7 +57,7 @@
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
-            <version>1.47.0</version>
+            <version>1.47.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
-            <version>1.47.4-SNAPSHOT</version>
+            <version>1.47.3</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/src/main/java/org/mongojack/DBCursor.java
+++ b/src/main/java/org/mongojack/DBCursor.java
@@ -307,29 +307,6 @@ public class DBCursor<T> extends DBQuery.AbstractBuilder<DBCursor<T>> implements
     }
 
     /**
-     * gets the number of times, so far, that the cursor retrieved a batch from
-     * the database
-     * 
-     * @return The number of get mores
-     * @deprecated there is no replacement for this method
-     */
-    @Deprecated
-    public int numGetMores() {
-        return cursor.numGetMores();
-    }
-
-    /**
-     * gets a simpleList containing the number of items received in each batch
-     * 
-     * @return The sizes of each batch
-     * @deprecated there is no replacement for this method
-     */
-    @Deprecated
-    public List<Integer> getSizes() {
-        return cursor.getSizes();
-    }
-
-    /**
      * Returns the number of objects through which the cursor has iterated.
      * 
      * @return the number of objects seen

--- a/src/main/java/org/mongojack/JacksonDBCollection.java
+++ b/src/main/java/org/mongojack/JacksonDBCollection.java
@@ -1134,14 +1134,6 @@ public class JacksonDBCollection<T, K> {
     }
 
     /**
-     * Clears all indices that have not yet been applied to this collection.
-     */
-    @Deprecated
-    public void resetIndexCache() {
-        dbCollection.resetIndexCache();
-    }
-
-    /**
      * Set hint fields for this collection (to optimize queries).
      * 
      * @param lst
@@ -1830,21 +1822,6 @@ public class JacksonDBCollection<T, K> {
      */
     @Deprecated
     public com.mongodb.MapReduceOutput mapReduce(MapReduceCommand command)
-            throws MongoException {
-        return dbCollection.mapReduce(command);
-    }
-
-    /**
-     * performs a map reduce operation
-     * 
-     * @param command
-     *            object representing the parameters
-     * @return The output
-     * @throws MongoException
-     *             If an error occurred
-     */
-    @Deprecated
-    public com.mongodb.MapReduceOutput mapReduce(DBObject command)
             throws MongoException {
         return dbCollection.mapReduce(command);
     }

--- a/src/main/java/org/mongojack/MapReduce.java
+++ b/src/main/java/org/mongojack/MapReduce.java
@@ -250,11 +250,6 @@ public class MapReduce {
                 command.setScope(scope);
             }
             command.setVerbose(verbose);
-            if (extra != null) {
-                for (String key : extra.keySet()) {
-                    command.addExtraOption(key, extra.get(key));
-                }
-            }
             return command;
         }
 

--- a/src/main/java/org/mongojack/MapReduce.java
+++ b/src/main/java/org/mongojack/MapReduce.java
@@ -16,10 +16,10 @@
  */
 package org.mongojack;
 
-import java.util.Map;
-
 import com.mongodb.DBObject;
 import com.mongodb.ReadPreference;
+
+import java.util.Map;
 
 /**
  * Map reduce command builder
@@ -100,7 +100,6 @@ public class MapReduce {
         private int limit;
         private Map<String, Object> scope;
         private boolean verbose = true;
-        private DBObject extra;
 
         private MapReduceCommand(String map, String reduce,
                 OutputType outputType, String collection, Class<T> resultType,
@@ -208,20 +207,6 @@ public class MapReduce {
          */
         public MapReduceCommand<T, K> setVerbose(boolean verbose) {
             this.verbose = verbose;
-            return this;
-        }
-
-        /**
-         * Set extra arguments to the map reduce command
-         * 
-         * @param extra
-         *            The extra arguments
-         * @return this command
-         * @deprecated  use the specific setter methods
-         */
-        @Deprecated
-        public MapReduceCommand<T, K> setExtra(DBObject extra) {
-            this.extra = extra;
             return this;
         }
 

--- a/src/main/java/org/mongojack/MapReduceOutput.java
+++ b/src/main/java/org/mongojack/MapReduceOutput.java
@@ -16,12 +16,10 @@
  */
 package org.mongojack;
 
+import com.mongodb.DBObject;
+
 import java.util.ArrayList;
 import java.util.Collection;
-
-import com.mongodb.CommandResult;
-import com.mongodb.DBObject;
-import com.mongodb.ServerAddress;
 
 /**
  * Represents the result of a Map/Reduce operation
@@ -114,33 +112,8 @@ public class MapReduceOutput<T, K> {
         return output.getEmitCount();
     }
 
-    /**
-     * Gets the raw command result of the operation.
-     *
-     * @return a CommandResult representing the output of the map-reduce in its raw form from the server.
-     * @deprecated It is not recommended to access the command result returned by the server as the format can change between releases. This
-     * has been replaced with a series of specific getters for the values on the CommandResult (
-     * getDuration, getEmitCount, getOutputCount, getInputCount).  The method {@code results()} will continue to return an {@code
-     * Iterable<T>}, that should be used to obtain the results of the map-reduce.
-     */
-    @Deprecated
-    public CommandResult getCommandResult() {
-        return output.getCommandResult();
-    }
-
     public DBObject getCommand() {
         return output.getCommand();
-    }
-
-    /**
-     * Get the server that the  command was run on.
-     *
-     * @return a ServerAddress of the server that the command ran against.
-     * @deprecated this method will be removed in a future release.  There is no replacement for it.
-     */
-    @Deprecated
-    public ServerAddress getServerUsed() {
-        return output.getServerUsed();
     }
 
     @Override

--- a/src/main/java/org/mongojack/WriteResult.java
+++ b/src/main/java/org/mongojack/WriteResult.java
@@ -170,74 +170,6 @@ public class WriteResult<T, K> {
     }
 
     /**
-     * Gets the last result from getLastError()
-     * 
-     * @return The last error
-     * @deprecated Use the appropriate {@code WriteConcern} and rely on the write operation to throw an exception on failure.  For
-     * successful writes, use the helper methods to retrieve specific values from the write response.
-     */
-    @Deprecated
-    public CommandResult getCachedLastError() {
-        return writeResult.getCachedLastError();
-
-    }
-
-    /**
-     * Gets the last {@link com.mongodb.WriteConcern} used when calling
-     * getLastError()
-     * 
-     * @return The last write concern.
-     * @deprecated there is no replacement for this method
-     */
-    @Deprecated
-    public WriteConcern getLastConcern() {
-        return writeResult.getLastConcern();
-
-    }
-
-    /**
-     * calls {@link WriteResult#getLastError(com.mongodb.WriteConcern)} with
-     * concern=null
-     * 
-     * @return The last error
-     * @deprecated Use the appropriate {@code WriteConcern} and allow the write operation to throw an exception on failure.  For
-     * successful writes, use the helper methods to retrieve specific values from the write response.
-     */
-    @Deprecated
-    public synchronized CommandResult getLastError() {
-        return writeResult.getLastError();
-    }
-
-    /**
-     * This method does following: - returns the existing CommandResult if
-     * concern is null or less strict than the concern it was obtained with -
-     * otherwise attempts to obtain a CommandResult by calling getLastError with
-     * the concern
-     * 
-     * @param concern
-     *            the concern
-     * @return The last error for the concern
-     * @deprecated Use the appropriate {@code WriteConcern} and rely on the write operation to throw an exception on failure.  For
-     * successful writes, use the helper methods to retrieve specific values from the write response.
-     */
-    @Deprecated
-    public synchronized CommandResult getLastError(WriteConcern concern) {
-        return writeResult.getLastError(concern);
-    }
-
-    /**
-     * Gets the error String ("err" field)
-     * 
-     * @return The error string
-     * @deprecated There should be no reason to use this method.  The error message will be in the exception thrown for an
-     * unsuccessful write operation.
-     */
-    @Deprecated
-    public String getError() {
-        return writeResult.getError();
-    }
-
-    /**
      * Gets the "n" field, which contains the number of documents affected in
      * the write operation.
      * 
@@ -265,32 +197,6 @@ public class WriteResult<T, K> {
      */
     public boolean isUpdateOfExisting() {
         return writeResult.isUpdateOfExisting();
-    }
-
-    /**
-     * Gets a field
-     * 
-     * @param name
-     *            field name
-     * @return The value
-     * @deprecated There should be no reason to use this method.  To get specific fields from a successful write,
-     * use the helper methods provided.  Any error-related fields will be in the exception thrown for an unsuccessful write operation.
-     */
-    @Deprecated
-    public Object getField(String name) {
-        return writeResult.getField(name);
-    }
-
-    /**
-     * Returns whether or not the result is lazy, meaning that getLastError was
-     * not called automatically
-     * 
-     * @return if it's lazy
-     * @deprecated there is no replacement for this method
-     */
-    @Deprecated
-    public boolean isLazy() {
-        return writeResult.isLazy();
     }
 
     @Override


### PR DESCRIPTION
https://github.com/devbliss/mongojack/issues/103

Minimal changes to get mongojack to compile with mongo-java-driver 3.0.0.
 
 - remove deprecated methods that use APIs not present in 3.0.0
  - depend on flapdoodle 1.47.4-SNAPSHOT w/ mongo-java-driver 3.0.0
  support
  - use mongo-java-driver 3.0.0 in dependencies with provided scope
  - bump version number to 2.3.2-SNAPSHOT

All tests pass.